### PR TITLE
Improve handling touch events

### DIFF
--- a/src/dpicker.js
+++ b/src/dpicker.js
@@ -178,9 +178,12 @@ function DPicker(element, options = {}) {
 
   let input = element.querySelector('input')
 
+  input.addEventListener('focus', input.blur)
   input.addEventListener('blur', this._events.inputBlur)
-  document.addEventListener('touchend', function() {
+  
+  document.addEventListener('touchend', event => {
     input.blur()
+    this._events.inputBlur(event)
   })
 
   return this


### PR DESCRIPTION
- improve close-on-touch event by triggering the blur manually
- blur the input element on focus, so no keyboard will be shown on touch-devices when opening the picker

This normalizes the behavior across more mobile browsers, including the new Safari on iOS 10.